### PR TITLE
Mongodb 3.4 no longer supports mirrored config servers. Removing 3.4 …

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -31,7 +31,7 @@ getValue() {
 version=${MongoDBVersion}
 
 if [ -z "$version" ] ; then
-  version="3.4"
+  version="3.2"
 fi
 
 if [ "${version}" == "2.6" ]; then

--- a/templates/MongoDB-NoVPC.template
+++ b/templates/MongoDB-NoVPC.template
@@ -33,9 +33,8 @@
         "MongoDBVersion": {
             "Description": "MongoDB version",
             "Type": "String",
-            "Default": "3.4",
+            "Default": "3.2",
             "AllowedValues": [
-                "3.4",
                 "3.2",
                 "3.0",
                 "2.6"

--- a/templates/MongoDB-VPC.template
+++ b/templates/MongoDB-VPC.template
@@ -39,9 +39,8 @@
         "MongoDBVersion": {
             "Description": "MongoDB version",
             "Type": "String",
-            "Default": "3.4",
+            "Default": "3.2",
             "AllowedValues": [
-                "3.4",
                 "3.2",
                 "3.0",
                 "2.6"


### PR DESCRIPTION
…from the allowed configurations.