### PR TITLE
feature/node type

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -55,7 +55,7 @@ yum -y install sysstat
 #################################################################
 #  Figure out what kind of node we are and set some values
 #################################################################
-NODE_TYPE=`getValue Name`
+NODE_TYPE=`getValue NodeType`
 IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)
 SHARD=s`getValue NodeShardIndex`
 NODES=`getValue ClusterReplicaSetCount`

--- a/scripts/init_replica.sh
+++ b/scripts/init_replica.sh
@@ -53,7 +53,7 @@ yum -y install sysstat
 #################################################################
 #  Figure out what kind of node we are and set some values
 #################################################################
-NODE_TYPE=`getValue Name`
+NODE_TYPE=`getValue NodeType`
 IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)
 SHARD=s`getValue ReplicaShardIndex`
 NODES=`getValue ClusterReplicaSetCount`

--- a/templates/MongoDB-NoVPC.template
+++ b/templates/MongoDB-NoVPC.template
@@ -838,6 +838,10 @@
                         "Value": "PrimaryReplicaNode0"
                     },
                     {
+                        "Key": "NodeType",
+                        "Value": "Primary"
+                    },
+                    {
                         "Key": "ClusterReplicaSetCount",
                         "Value": {
                             "Ref": "ClusterReplicaSetCount"
@@ -863,6 +867,7 @@
                         "Key": "NodeShardIndex",
                         "Value": "-1"
                     }
+
                 ],
                 "BlockDeviceMappings": [
                     {
@@ -1031,6 +1036,10 @@
                     {
                         "Key": "Name",
                         "Value": "PrimaryReplicaNode0"
+                    },
+                    {
+                        "Key": "NodeType",
+                        "Value": "Primary"
                     },
                     {
                         "Key": "ClusterReplicaSetCount",
@@ -1391,6 +1400,10 @@
                         "Value": "PrimaryReplicaNode00"
                     },
                     {
+                        "Key": "NodeType",
+                        "Value": "Primary"
+                    },
+                    {
                         "Key": "ClusterReplicaSetCount",
                         "Value": {
                             "Ref": "ClusterReplicaSetCount"
@@ -1584,6 +1597,10 @@
                     {
                         "Key": "Name",
                         "Value": "PrimaryReplicaNode00"
+                    },
+                    {
+                        "Key": "NodeType",
+                        "Value": "Primary"
                     },
                     {
                         "Key": "ClusterReplicaSetCount",
@@ -1944,6 +1961,10 @@
                         "Value": "SecondaryReplicaNode0"
                     },
                     {
+                        "Key": "NodeType",
+                        "Value": "Secondary"
+                    },
+                    {
                         "Key": "ClusterReplicaSetCount",
                         "Value": {
                             "Ref": "ClusterReplicaSetCount"
@@ -2137,6 +2158,10 @@
                     {
                         "Key": "Name",
                         "Value": "SecondaryReplicaNode0"
+                    },
+                    {
+                        "Key": "NodeType",
+                        "Value": "Secondary"
                     },
                     {
                         "Key": "ClusterReplicaSetCount",
@@ -2497,6 +2522,10 @@
                         "Value": "SecondaryReplicaNode00"
                     },
                     {
+                        "Key": "NodeType",
+                        "Value": "Secondary"
+                    },
+                    {
                         "Key": "ClusterReplicaSetCount",
                         "Value": {
                             "Ref": "ClusterReplicaSetCount"
@@ -2690,6 +2719,10 @@
                     {
                         "Key": "Name",
                         "Value": "SecondaryReplicaNode00"
+                    },
+                    {
+                        "Key": "NodeType",
+                        "Value": "Secondary"
                     },
                     {
                         "Key": "ClusterReplicaSetCount",
@@ -3050,6 +3083,10 @@
                         "Value": "SecondaryReplicaNode1"
                     },
                     {
+                        "Key": "NodeType",
+                        "Value": "Secondary"
+                    },
+                    {
                         "Key": "ClusterReplicaSetCount",
                         "Value": {
                             "Ref": "ClusterReplicaSetCount"
@@ -3243,6 +3280,10 @@
                     {
                         "Key": "Name",
                         "Value": "SecondaryReplicaNode1"
+                    },
+                    {
+                        "Key": "NodeType",
+                        "Value": "Secondary"
                     },
                     {
                         "Key": "ClusterReplicaSetCount",
@@ -3603,6 +3644,10 @@
                         "Value": "SecondaryReplicaNode01"
                     },
                     {
+                        "Key": "NodeType",
+                        "Value": "Secondary"
+                    },
+                    {
                         "Key": "ClusterReplicaSetCount",
                         "Value": {
                             "Ref": "ClusterReplicaSetCount"
@@ -3796,6 +3841,10 @@
                     {
                         "Key": "Name",
                         "Value": "SecondaryReplicaNode01"
+                    },
+                    {
+                        "Key": "NodeType",
+                        "Value": "Secondary"
                     },
                     {
                         "Key": "ClusterReplicaSetCount",
@@ -4156,6 +4205,10 @@
                         "Value": "PrimaryReplicaNode10"
                     },
                     {
+                        "Key": "NodeType",
+                        "Value": "Primary"
+                    },
+                    {
                         "Key": "ClusterReplicaSetCount",
                         "Value": {
                             "Ref": "ClusterReplicaSetCount"
@@ -4349,6 +4402,10 @@
                     {
                         "Key": "Name",
                         "Value": "PrimaryReplicaNode10"
+                    },
+                    {
+                        "Key": "NodeType",
+                        "Value": "Primary"
                     },
                     {
                         "Key": "ClusterReplicaSetCount",
@@ -4709,6 +4766,10 @@
                         "Value": "SecondaryReplicaNode10"
                     },
                     {
+                        "Key": "NodeType",
+                        "Value": "Secondary"
+                    },
+                    {
                         "Key": "ClusterReplicaSetCount",
                         "Value": {
                             "Ref": "ClusterReplicaSetCount"
@@ -4902,6 +4963,10 @@
                     {
                         "Key": "Name",
                         "Value": "SecondaryReplicaNode10"
+                    },
+                    {
+                        "Key": "NodeType",
+                        "Value": "Secondary"
                     },
                     {
                         "Key": "ClusterReplicaSetCount",
@@ -5262,6 +5327,10 @@
                         "Value": "SecondaryReplicaNode11"
                     },
                     {
+                        "Key": "NodeType",
+                        "Value": "Secondary"
+                    },
+                    {
                         "Key": "ClusterReplicaSetCount",
                         "Value": {
                             "Ref": "ClusterReplicaSetCount"
@@ -5455,6 +5524,10 @@
                     {
                         "Key": "Name",
                         "Value": "SecondaryReplicaNode11"
+                    },
+                    {
+                        "Key": "NodeType",
+                        "Value": "Secondary"
                     },
                     {
                         "Key": "ClusterReplicaSetCount",
@@ -5815,6 +5888,10 @@
                         "Value": "PrimaryReplicaNode20"
                     },
                     {
+                        "Key": "NodeType",
+                        "Value": "Primary"
+                    },
+                    {
                         "Key": "ClusterReplicaSetCount",
                         "Value": {
                             "Ref": "ClusterReplicaSetCount"
@@ -6008,6 +6085,10 @@
                     {
                         "Key": "Name",
                         "Value": "PrimaryReplicaNode20"
+                    },
+                    {
+                        "Key": "NodeType",
+                        "Value": "Primary"
                     },
                     {
                         "Key": "ClusterReplicaSetCount",
@@ -6368,6 +6449,10 @@
                         "Value": "SecondaryReplicaNode20"
                     },
                     {
+                        "Key": "NodeType",
+                        "Value": "Secondary"
+                    },
+                    {
                         "Key": "ClusterReplicaSetCount",
                         "Value": {
                             "Ref": "ClusterReplicaSetCount"
@@ -6561,6 +6646,10 @@
                     {
                         "Key": "Name",
                         "Value": "SecondaryReplicaNode20"
+                    },
+                    {
+                        "Key": "NodeType",
+                        "Value": "Secondary"
                     },
                     {
                         "Key": "ClusterReplicaSetCount",
@@ -6921,6 +7010,10 @@
                         "Value": "SecondaryReplicaNode21"
                     },
                     {
+                        "Key": "NodeType",
+                        "Value": "Secondary"
+                    },
+                    {
                         "Key": "ClusterReplicaSetCount",
                         "Value": {
                             "Ref": "ClusterReplicaSetCount"
@@ -7114,6 +7207,10 @@
                     {
                         "Key": "Name",
                         "Value": "SecondaryReplicaNode21"
+                    },
+                    {
+                        "Key": "NodeType",
+                        "Value": "Secondary"
                     },
                     {
                         "Key": "ClusterReplicaSetCount",

--- a/templates/MongoDB-VPC.template
+++ b/templates/MongoDB-VPC.template
@@ -1503,6 +1503,10 @@
                         "Value": "PrimaryReplicaNode0"
                     },
                     {
+                        "Key": "NodeType",
+                        "Value": "Primary"
+                    },
+                    {
                         "Key": "ClusterReplicaSetCount",
                         "Value": {
                             "Ref": "ClusterReplicaSetCount"
@@ -1697,6 +1701,10 @@
                     {
                         "Key": "Name",
                         "Value": "PrimaryReplicaNode0"
+                    },
+                    {
+                        "Key": "NodeType",
+                        "Value": "Primary"
                     },
                     {
                         "Key": "ClusterReplicaSetCount",
@@ -2058,6 +2066,10 @@
                         "Value": "PrimaryReplicaNode00"
                     },
                     {
+                        "Key": "NodeType",
+                        "Value": "Primary"
+                    },
+                    {
                         "Key": "ClusterReplicaSetCount",
                         "Value": {
                             "Ref": "ClusterReplicaSetCount"
@@ -2251,6 +2263,10 @@
                     {
                         "Key": "Name",
                         "Value": "PrimaryReplicaNode00"
+                    },
+                    {
+                        "Key": "NodeType",
+                        "Value": "Primary"
                     },
                     {
                         "Key": "ClusterReplicaSetCount",
@@ -2611,6 +2627,10 @@
                         "Value": "SecondaryReplicaNode0"
                     },
                     {
+                        "Key": "NodeType",
+                        "Value": "Primary"
+                    },
+                    {
                         "Key": "ClusterReplicaSetCount",
                         "Value": {
                             "Ref": "ClusterReplicaSetCount"
@@ -2804,6 +2824,10 @@
                     {
                         "Key": "Name",
                         "Value": "SecondaryReplicaNode0"
+                    },
+                    {
+                        "Key": "NodeType",
+                        "Value": "Secondary"
                     },
                     {
                         "Key": "ClusterReplicaSetCount",
@@ -3164,6 +3188,10 @@
                         "Value": "SecondaryReplicaNode00"
                     },
                     {
+                        "Key": "NodeType",
+                        "Value": "Secondary"
+                    },
+                    {
                         "Key": "ClusterReplicaSetCount",
                         "Value": {
                             "Ref": "ClusterReplicaSetCount"
@@ -3357,6 +3385,10 @@
                     {
                         "Key": "Name",
                         "Value": "SecondaryReplicaNode00"
+                    },
+                    {
+                        "Key": "NodeType",
+                        "Value": "Secondary"
                     },
                     {
                         "Key": "ClusterReplicaSetCount",
@@ -3717,6 +3749,10 @@
                         "Value": "SecondaryReplicaNode1"
                     },
                     {
+                        "Key": "NodeType",
+                        "Value": "Secondary"
+                    },
+                    {
                         "Key": "ClusterReplicaSetCount",
                         "Value": {
                             "Ref": "ClusterReplicaSetCount"
@@ -3910,6 +3946,10 @@
                     {
                         "Key": "Name",
                         "Value": "SecondaryReplicaNode1"
+                    },
+                    {
+                        "Key": "NodeType",
+                        "Value": "Secondary"
                     },
                     {
                         "Key": "ClusterReplicaSetCount",
@@ -4270,6 +4310,10 @@
                         "Value": "SecondaryReplicaNode01"
                     },
                     {
+                        "Key": "NodeType",
+                        "Value": "Secondary"
+                    },
+                    {
                         "Key": "ClusterReplicaSetCount",
                         "Value": {
                             "Ref": "ClusterReplicaSetCount"
@@ -4463,6 +4507,10 @@
                     {
                         "Key": "Name",
                         "Value": "SecondaryReplicaNode01"
+                    },
+                    {
+                        "Key": "NodeType",
+                        "Value": "Secondary"
                     },
                     {
                         "Key": "ClusterReplicaSetCount",
@@ -4823,6 +4871,10 @@
                         "Value": "PrimaryReplicaNode10"
                     },
                     {
+                        "Key": "NodeType",
+                        "Value": "Primary"
+                    },
+                    {
                         "Key": "ClusterReplicaSetCount",
                         "Value": {
                             "Ref": "ClusterReplicaSetCount"
@@ -5016,6 +5068,10 @@
                     {
                         "Key": "Name",
                         "Value": "PrimaryReplicaNode10"
+                    },
+                    {
+                        "Key": "NodeType",
+                        "Value": "Primary"
                     },
                     {
                         "Key": "ClusterReplicaSetCount",
@@ -5376,6 +5432,10 @@
                         "Value": "SecondaryReplicaNode10"
                     },
                     {
+                        "Key": "NodeType",
+                        "Value": "Secondary"
+                    },
+                    {
                         "Key": "ClusterReplicaSetCount",
                         "Value": {
                             "Ref": "ClusterReplicaSetCount"
@@ -5569,6 +5629,10 @@
                     {
                         "Key": "Name",
                         "Value": "SecondaryReplicaNode10"
+                    },
+                    {
+                        "Key": "NodeType",
+                        "Value": "Secondary"
                     },
                     {
                         "Key": "ClusterReplicaSetCount",
@@ -5928,6 +5992,7 @@
                         "Key": "Name",
                         "Value": "SecondaryReplicaNode11"
                     },
+
                     {
                         "Key": "ClusterReplicaSetCount",
                         "Value": {
@@ -6122,6 +6187,10 @@
                     {
                         "Key": "Name",
                         "Value": "SecondaryReplicaNode11"
+                    },
+                    {
+                        "Key": "NodeType",
+                        "Value": "Secondary"
                     },
                     {
                         "Key": "ClusterReplicaSetCount",
@@ -6482,6 +6551,10 @@
                         "Value": "PrimaryReplicaNode20"
                     },
                     {
+                        "Key": "NodeType",
+                        "Value": "Primary"
+                    },
+                    {
                         "Key": "ClusterReplicaSetCount",
                         "Value": {
                             "Ref": "ClusterReplicaSetCount"
@@ -6675,6 +6748,10 @@
                     {
                         "Key": "Name",
                         "Value": "PrimaryReplicaNode20"
+                    },
+                    {
+                        "Key": "NodeType",
+                        "Value": "Primary"
                     },
                     {
                         "Key": "ClusterReplicaSetCount",
@@ -7035,6 +7112,10 @@
                         "Value": "SecondaryReplicaNode20"
                     },
                     {
+                        "Key": "NodeType",
+                        "Value": "Secondary"
+                    },
+                    {
                         "Key": "ClusterReplicaSetCount",
                         "Value": {
                             "Ref": "ClusterReplicaSetCount"
@@ -7228,6 +7309,10 @@
                     {
                         "Key": "Name",
                         "Value": "SecondaryReplicaNode20"
+                    },
+                    {
+                        "Key": "NodeType",
+                        "Value": "Secondary"
                     },
                     {
                         "Key": "ClusterReplicaSetCount",
@@ -7588,6 +7673,10 @@
                         "Value": "SecondaryReplicaNode21"
                     },
                     {
+                        "Key": "NodeType",
+                        "Value": "Secondary"
+                    },
+                    {
                         "Key": "ClusterReplicaSetCount",
                         "Value": {
                             "Ref": "ClusterReplicaSetCount"
@@ -7781,6 +7870,10 @@
                     {
                         "Key": "Name",
                         "Value": "SecondaryReplicaNode21"
+                    },
+                    {
+                        "Key": "NodeType",
+                        "Value": "Secondary"
                     },
                     {
                         "Key": "ClusterReplicaSetCount",

--- a/templates/mongodb-node.template
+++ b/templates/mongodb-node.template
@@ -60,6 +60,10 @@
             "Description": "Instance Name",
             "Type": "String"
         },
+        "NodeType": {
+            "Description": "Instance Node Type",
+            "Type": "String"
+        },
         "NodeReplicaSetIndex": {
             "Description": "Instance Index",
             "Type": "String"
@@ -227,6 +231,12 @@
                         "Key": "Name",
                         "Value": {
                             "Ref": "ReplicaNodeNameTag"
+                        }
+                    },
+                    {
+                        "Key": "NodeType",
+                        "Value": {
+                            "Ref": "NodeType"
                         }
                     },
                     {
@@ -494,6 +504,10 @@
         "NodeNameTag": {
             "Description": "Node Name Tag",
             "Value" : { "Ref": "ReplicaNodeNameTag"}
+        },
+        "NodeType": {
+            "Description": "Node Name Tag",
+            "Value" : { "Ref": "NodeType"}
         }
     }
 }

--- a/templates/mongodb.template
+++ b/templates/mongodb.template
@@ -541,6 +541,7 @@
                         ]
                     },
                     "ReplicaNodeNameTag": "PrimaryReplicaNode0",
+                    "NodeType": "Primary",
                     "NodeReplicaSetIndex": "0",
                     "ReplicaShardIndex": {
                         "Ref": "ReplicaShardIndex"
@@ -647,6 +648,7 @@
                         ]
                     },
                     "ReplicaNodeNameTag": "SecondaryReplicaNode0",
+                    "NodeType": "Secondary",
                     "NodeReplicaSetIndex": "1",
                     "ReplicaShardIndex": {
                         "Ref": "ReplicaShardIndex"
@@ -754,6 +756,7 @@
                         ]
                     },
                     "ReplicaNodeNameTag": "SecondaryReplicaNode1",
+                    "NodeType": "Secondary",
                     "NodeReplicaSetIndex": "2",
                     "ReplicaShardIndex": {
                         "Ref": "ReplicaShardIndex"


### PR DESCRIPTION
To setup AWS Mongo QuickStart Easily, you need to set your mongo instances names with "**Primary***" or "**Secondary***", but if you don't want to change your naming conventions for only mongo instances, you couldn't do it with existing templates / scripts. To solve this issue, I've changed templates and scripts a bit, I've created a new tag as called "`NodeType`" and update `init.sh `script to get "Node Type" from this tag. 