### PR TITLE
Updated MongoDB version to 3.6, updated install scripts and templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # MongoDB on the AWS Cloud
-> MongoDB version 3.4
+> MongoDB version 3.6
 
 ## Deployment Options
 AWS Quick Start Team
@@ -12,7 +12,7 @@ The following links are for your convenience. Before you launch the Quick Start,
 
 ## Change Log
 ### April 2017
-* Changed version to MongoDB 3.4
+* Changed version to MongoDB 3.6
 * Removed Sharding Option and Configuration Parameters.
 * Simplified init script init_replica.sh
 * Added test cases

--- a/scripts/init_replica.sh
+++ b/scripts/init_replica.sh
@@ -107,7 +107,7 @@ echo "* soft nofile 64000
 enable_all_listen() {
   for f in /etc/mongo*.conf
   do
-    sed -e '/bindIp/s/^/#/g' -i ${f}
+    sed -e '/bindIp/s/^/ bindIp: 0.0.0.0 #/' -i ${f}
     sed -e '/bind_ip/s/^/#/g' -i ${f}
     echo " Set listen to all interfaces : ${f}"
   done
@@ -173,6 +173,7 @@ chown mongod:mongod /var/run/mongod
 
 echo "net:" > mongod.conf
 echo "  port:" >> mongod.conf
+echo "  bindIp: 0.0.0.0" >> mongod.conf
 echo "" >> mongod.conf
 echo "systemLog:" >> mongod.conf
 echo "  destination: file" >> mongod.conf

--- a/templates/mongodb-master.template
+++ b/templates/mongodb-master.template
@@ -320,6 +320,7 @@
 	        "Type": "String",
 	        "Description": "MongoDB version",
 	        "AllowedValues": [
+				"3.6",
 	            "3.4",
                 "3.2"
 	        ]

--- a/templates/mongodb-node.template
+++ b/templates/mongodb-node.template
@@ -110,6 +110,7 @@
             "Type": "String",
             "Default": "3.4",
             "AllowedValues": [
+                "3.6",
                 "3.4",
                 "3.2"
             ]

--- a/templates/mongodb.template
+++ b/templates/mongodb.template
@@ -124,6 +124,7 @@
             "Type": "String",
             "Default": "3.4",
             "AllowedValues": [
+                "3.6",
                 "3.4",
                 "3.2"
             ]


### PR DESCRIPTION
As per discussion on:
https://github.com/aws-quickstart/quickstart-mongodb/pull/21

Here is a PR with fully functional changes to quickstart, to handle mongodb 3.6.
Updated templates, to handle 3.6, not default

Updated init_replica.sh script, to handle new bindIp behavior of mongodb 3.6.
Proposed change is to add bindIp to 0.0.0.0, behaving the same way as 3.4 does without bindIp


All files under this PR are licensed under:
Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.