### PR TITLE
Fixes bucket name param sent to node template

### DIFF
--- a/templates/mongodb.template
+++ b/templates/mongodb.template
@@ -548,7 +548,7 @@
                 },
                 "Parameters": {
                     "QSS3BucketName": {
-                        "Ref": "QSS3BucketName"
+                        "Fn::If": ["UsingDefaultBucket",  { "Fn::Sub": "${QSS3BucketName}-${AWS::Region}" }, {"Ref": "QSS3BucketName"}]
                     },
                     "QSS3KeyPrefix": {
                         "Ref": "QSS3KeyPrefix"
@@ -655,7 +655,7 @@
                 },
                 "Parameters": {
                     "QSS3BucketName": {
-                        "Ref": "QSS3BucketName"
+                        "Fn::If": ["UsingDefaultBucket",  { "Fn::Sub": "${QSS3BucketName}-${AWS::Region}" }, {"Ref": "QSS3BucketName"}]
                     },
                     "QSS3KeyPrefix": {
                         "Ref": "QSS3KeyPrefix"
@@ -763,7 +763,7 @@
                 },
                 "Parameters": {
                     "QSS3BucketName": {
-                        "Ref": "QSS3BucketName"
+                        "Fn::If": ["UsingDefaultBucket",  { "Fn::Sub": "${QSS3BucketName}-${AWS::Region}" }, {"Ref": "QSS3BucketName"}]
                     },
                     "QSS3KeyPrefix": {
                         "Ref": "QSS3KeyPrefix"


### PR DESCRIPTION
Fixes bucket name parameter sent to node template

Issue #46 

Currently Mongo DB deployment times out at node creation. The reason for this is that node template attempts to copy some files from S3 bucket to which it has no access.
For example EC2 instance has access policy to S3 bucket aws-quickstart-eu-central-1 and bootstrap script attempts to download scripts from bucket aws-quickstart. As a result bootstrap script fails, signal final status is never executed and the whole stack is rolled back when timeout is reached.

Alternatively a fix could be implemented in node template so that it uses a bucket name to which the instance has permissions.